### PR TITLE
Add Target IPs to selector functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,13 @@
 # Ec2DeploymentSelector
 
-Welcome to your new gem! In this directory, you'll find the files you need to be able to package up your Ruby library into a gem. Put your Ruby code in the file `lib/ec2_deployment_selector`. To experiment with that code, run `bin/console` for an interactive prompt.
+EC2 Deployment Selector is a Ruby gem that simplifies the process of selecting Amazon EC2 instances for deployment. It provides an interactive interface for filtering and selecting instances based on tags, regions, and application names. It's particularly useful when integrated with Capistrano for deployment automation.
 
-TODO: Delete this and the text above, and describe your gem
+This gem allows you to:
+- Fetch EC2 instances across multiple AWS regions
+- Filter instances by application name and custom tags
+- Present instances in a formatted table with color-coded status information
+- Interactively select instances for deployment
+- Support non-interactive mode for CI/CD pipelines
 
 ## Installation
 
@@ -22,7 +27,86 @@ Or install it yourself as:
 
 ## Usage
 
-TODO: Write usage instructions here
+### Basic Usage with Capistrano
+
+In your `config/deploy.rb` file, require the gem and initialize the selector:
+
+```ruby
+require "ec2_deployment_selector"
+
+configure_ec2_selector = ->(env) do
+  ec2_deployment_selector = Ec2DeploymentSelector::Selector.new(
+    access_key_id: ENV["ACCESS_KEY_ID"],
+    secret_access_key: ENV["SECRET_ACCESS_KEY"],
+    application_name: fetch(:application),
+    filters: {
+      "ENV_Type" => env
+    }
+  )
+
+  ec2_deployment_selector.render_all_instances
+
+  # Interactive instance selection
+  ec2_deployment_selector.prompt_select_instances
+  ec2_deployment_selector.confirm_selected_instances
+
+  # Configure servers for deployment
+  ec2_deployment_selector.selected_instances_public_ips.each do |instance_ip|
+    server instance_ip,
+      user: "deploy",
+      roles: %w{app},
+      ssh_options: { forward_agent: true }
+  end
+end
+
+# Call the configurator for each environment
+configure_ec2_selector.call('production') if fetch(:stage) == :production
+configure_ec2_selector.call('staging') if fetch(:stage) == :staging
+```
+
+### Using with Target IP Filtering
+
+You can specify target IPs through environment variables:
+
+```ruby
+if ENV["TARGET_IPS"] && !ENV["TARGET_IPS"].empty?
+  target_ips = ENV["TARGET_IPS"].split(',').map(&:strip)
+
+  all_instances = ec2_deployment_selector.instance_variable_get(:@all_instances) || []
+  selected_instances = all_instances.select do |instance|
+    public_ip = instance.public_ip_address
+    private_ip = instance.private_ip_address
+
+    target_ips.include?(public_ip) || target_ips.include?(private_ip)
+  end
+
+  ec2_deployment_selector.instance_variable_set(:@selected_instances, selected_instances)
+end
+```
+
+### Non-Interactive Mode
+
+For CI/CD pipelines, set the `NON_INTERACTIVE` environment variable:
+
+```bash
+NON_INTERACTIVE=true bundle exec cap production deploy
+```
+
+### SSH Options with a Jump Box
+
+When working with instances behind a bastion host:
+
+```ruby
+ssh_options = {}
+unless ENV["HOPPER_SSH_PROXY"] == "false"
+  ssh_options = {
+    forward_agent: true,
+    proxy: Net::SSH::Proxy::Command.new("ssh hopper -W %h:%p"),
+  }
+end
+
+# Apply these options when configuring servers
+```
 
 ## Development
 

--- a/lib/ec2_deployment_selector/selector.rb
+++ b/lib/ec2_deployment_selector/selector.rb
@@ -67,7 +67,7 @@ module Ec2DeploymentSelector
         row(instance, include_num_column)
       end
 
-      headings = ["Name", "Instance Status", "Layers", "Public IP", "Private IP", "Region"].map { |h| h.colorize(mode: :bold) }
+      headings = ["Name", "Instance Status", "Layers", "Public IP", "Private IP", "Region", "Deployable"].map { |h| h.colorize(mode: :bold) }
       headings = ["Num"] + headings if include_num_column
       table = Terminal::Table.new(
         title: title,
@@ -85,7 +85,8 @@ module Ec2DeploymentSelector
         instance.layers,
         instance.public_ip_address,
         instance.private_ip_address,
-        instance.region
+        instance.region,
+        instance.deployable? ? "Yes" : "No",
       ]
       if include_num_column
         number = instance.deployable? ? instance.number : "-"

--- a/lib/ec2_deployment_selector/selector.rb
+++ b/lib/ec2_deployment_selector/selector.rb
@@ -67,7 +67,7 @@ module Ec2DeploymentSelector
         row(instance, include_num_column)
       end
 
-      headings = ["Name", "Instance Status", "Chef Status", "Layers", "Public IP", "Region"].map { |h| h.colorize(mode: :bold) }
+      headings = ["Name", "Instance Status", "Layers", "Public IP", "Private IP", "Region"].map { |h| h.colorize(mode: :bold) }
       headings = ["Num"] + headings if include_num_column
       table = Terminal::Table.new(
         title: title,
@@ -82,9 +82,9 @@ module Ec2DeploymentSelector
       row = [
         instance.name,
         instance.state,
-        instance.chef_status,
         instance.layers,
         instance.public_ip_address,
+        instance.private_ip_address,
         instance.region
       ]
       if include_num_column

--- a/lib/ec2_deployment_selector/wrappers/ec2_instance.rb
+++ b/lib/ec2_deployment_selector/wrappers/ec2_instance.rb
@@ -10,6 +10,7 @@ module Ec2DeploymentSelector
       CHEF_STATUS_TAG_KEY = "ChefStatus"
       NAME_TAG_KEY = "Name"
       LAYERS_TAG_KEY = "Layers"
+      DEPLOYABLE_TAG_KEY = "Deployable"
 
       attr_accessor :number, :object
 
@@ -21,13 +22,20 @@ module Ec2DeploymentSelector
         object.public_ip_address
       end
 
+      def private_ip_address
+        object.private_ip_address
+      end
+
       def instance_type
         object.instance_type
       end
 
       def deployable?
-        # TODO: include chef status
-        object.state.name == "running"
+        is_running = object.state.name == "running"
+        deployable_tag = tag_value(DEPLOYABLE_TAG_KEY)
+        is_deployable = deployable_tag.nil? || deployable_tag.empty? || deployable_tag.downcase != "false"
+
+        is_running && is_deployable
       end
 
       def name


### PR DESCRIPTION
This pull request introduces significant enhancements to the `Ec2DeploymentSelector` Ruby gem, including improved documentation, expanded functionality for EC2 instance filtering and selection, and updates to the instance rendering logic. The most important changes are grouped into documentation updates, instance rendering improvements, and new functionality for instance filtering.

### New Functionality for Instance Filtering
* Added a `DEPLOYABLE_TAG_KEY` constant and updated the `deployable?` method in `ec2_instance.rb` to include logic for checking a "Deployable" tag, ensuring instances are only considered deployable if they are running and the tag is not explicitly set to "false." [[1]](diffhunk://#diff-d26e332f200dccc100828a5ce7c6dd5ea9618eb7498ea0f47b80d91befdae0edR13) [[2]](diffhunk://#diff-d26e332f200dccc100828a5ce7c6dd5ea9618eb7498ea0f47b80d91befdae0edR25-R38)

### Instance Rendering Improvements
* Modified the `render_table` method in `selector.rb` to replace the "Chef Status" column with "Private IP" and updated the row data to include private IP addresses. [[1]](diffhunk://#diff-a959dfb6bd7045cdb3d584ddd6a365bb9b3ef2c14ed43f8031ad46a29735271fL70-R70) [[2]](diffhunk://#diff-a959dfb6bd7045cdb3d584ddd6a365bb9b3ef2c14ed43f8031ad46a29735271fL85-R87)

### Documentation Updates
* Updated the `README.md` file to provide a detailed description of the gem's purpose, features, and usage, including examples for integration with Capistrano, non-interactive mode for CI/CD pipelines, and SSH options with a jump box. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L3-R10) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L25-R109)